### PR TITLE
#5: Add 'stores' directory to 'defineNuxtConfig.imports.dirs'

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,9 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   rootDir: "./src",
   modules: ["@pinia/nuxt", "@nuxtjs/eslint-module"],
+  imports: {
+    dirs: ['stores']
+  },
   pinia: {
     autoImports: ["createPinia","defineStore", "storeToRefs"],
   },


### PR DESCRIPTION
## Issue

closed #5 .

## 内容

- [x] `nuxt.config.ts`の`imports.dirs`に **stores**を追加
  - `components`、`composables`と同じようにAuto Importsされる

### 関連
- #5 
- #8 

## 参考
- https://nuxt.com/docs/api/configuration/nuxt-config#imports