### PR TITLE
#14:  add '@pinia-plugin-persistedstate' plugin for Pinia

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
     "composables",
     "histoire",
     "pinia",
+    "persistedstate"
   ]
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,7 +2,11 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
   rootDir: "./src",
-  modules: ["@pinia/nuxt", "@nuxtjs/eslint-module"],
+  modules: [
+    "@pinia/nuxt",
+    "@pinia-plugin-persistedstate/nuxt",
+    "@nuxtjs/eslint-module"
+  ],
   imports: {
     dirs: ['stores']
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,12 @@ export default defineNuxtConfig({
     dirs: ['stores']
   },
   pinia: {
-    autoImports: ["createPinia","defineStore", "storeToRefs"],
+    autoImports: [
+      "createPinia",
+      "defineStore",
+      "storeToRefs",
+      "setActivePinia"
+    ],
   },
   eslint: {
     cache: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nuxt/devtools": "latest",
         "@nuxt/eslint-config": "0.1.1",
         "@nuxtjs/eslint-module": "^4.1.0",
+        "@pinia-plugin-persistedstate/nuxt": "^1.1.1",
         "@types/node": "^18.17.1",
         "@volar/vue-typescript": "^1.6.5",
         "eslint": "^8.46.0",
@@ -2904,6 +2905,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@pinia-plugin-persistedstate/nuxt": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pinia-plugin-persistedstate/nuxt/-/nuxt-1.1.1.tgz",
+      "integrity": "sha512-b6ZNP3Re8COmfZEpj4KQmbp2TuDKrLggDFLZa8FiJF68xE/oCsPXIuXUvAt8E4ht/5sq4Z/grlA+iGXaI2aeKQ==",
+      "dev": true,
+      "dependencies": {
+        "@nuxt/kit": "^3.2.3",
+        "defu": "^6.1.2",
+        "pinia-plugin-persistedstate": ">=3.1.0"
+      },
+      "peerDependencies": {
+        "@pinia/nuxt": "^0.4.4"
       }
     },
     "node_modules/@pinia/nuxt": {
@@ -11429,6 +11444,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pinia-plugin-persistedstate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-3.2.0.tgz",
+      "integrity": "sha512-tZbNGf2vjAQcIm7alK40sE51Qu/m9oWr+rEgNm/2AWr1huFxj72CjvpQcIQzMknDBJEkQznCLAGtJTIcLKrKdw==",
+      "dev": true,
+      "peerDependencies": {
+        "pinia": "^2.0.0"
       }
     },
     "node_modules/pinkie": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nuxt/devtools": "latest",
     "@nuxt/eslint-config": "0.1.1",
     "@nuxtjs/eslint-module": "^4.1.0",
+    "@pinia-plugin-persistedstate/nuxt": "^1.1.1",
     "@types/node": "^18.17.1",
     "@volar/vue-typescript": "^1.6.5",
     "eslint": "^8.46.0",


### PR DESCRIPTION
## Issue

closed #14 .

## 内容

- [x] [@pinia-plugin-persistedstate](https://nuxt.com/modules/pinia-plugin-persistedstate)を追加
- [x] PiniaのAutoImports設定に`setActivePinia`を追加しました

### 備考
- [Vue3(Nuxt3)にて、PiniaさんでStoreを永続化する実験したよ](https://zenn.dev/mihorin1729/articles/f29073e516bc8c)

### 関連

## レビュアー確認項目

- [x] `npm run dev`コマンドを実行しhttp://localhost:3000 にアクセスする。ページのリロードを行ってもカウントが減っていないこと
  - 備考: #8 で利用したサンプルstoresを使い回している