### PR TITLE
#10: add '@typescript-eslint/no-import-side-effects' plugin for ESLint 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,18 +15,16 @@ module.exports = {
   extends: ["@nuxt/eslint-config", "prettier"],
   rules: {
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/consistent-type-imports": "off",
     "no-console": process.env.NODE_ENV === "production" ? "error" : "warn",
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "warn",
-    "@typescript-eslint/consistent-type-imports": [
-      "error",
-      { prefer: "type-imports", disallowTypeAnnotations: true, fixStyle: 'inline-type-imports' }
-    ]
   },
   overrides: [
     {
-      files: ["*.ts", "*.vue"],
+      files: ["*.ts", "*.mts", "*.vue"],
       rules: {
         "@typescript-eslint/explicit-function-return-type": "error",
+        "@typescript-eslint/consistent-type-imports": "error",
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,12 @@ module.exports = {
       files: ["*.ts", "*.mts", "*.vue"],
       rules: {
         "@typescript-eslint/explicit-function-return-type": "error",
-        "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/consistent-type-imports": [
+          "error",
+          {
+            "disallowTypeAnnotations": false,
+          }
+        ],
         "@typescript-eslint/no-import-side-effects": "error",
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,8 @@
  * - NOTE: Return Typesの明示を必須にする
  * @see ESLint Rules: {@link https://typescript-eslint.io/rules/consistent-type-imports/ | consistent-type-imports}
  * - NOTE: 型のimportを必須にする
+ * @see ESLint Rules: {@link https://typescript-eslint.io/rules/no-import-type-side-effects/ | no-import-type-side-effects}
+ * - NOTE: 型のimportで副作用を禁止する
  */
 module.exports = {
   root: true,
@@ -16,6 +18,7 @@ module.exports = {
   rules: {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/consistent-type-imports": "off",
+    "@typescript-eslint/no-import-side-effects": "off",
     "no-console": process.env.NODE_ENV === "production" ? "error" : "warn",
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "warn",
   },
@@ -25,6 +28,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/explicit-function-return-type": "error",
         "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/no-import-side-effects": "error",
       },
     },
   ],


### PR DESCRIPTION
## Issue

closed #10 .

## 内容

- [x] ESLintプラグイン：`@typescript-eslint/no-import-side-effects`を追加
  - https://typescript-eslint.io/rules/no-import-type-side-effects/
- [x] `@typescript-eslint/consistent-type-imports`ルールを一部修正
  - https://github.com/nuxt/nuxt/blob/main/.eslintrc#L81-L86 を参考に 

### 関連
- #16 
