### PR TITLE
#25: add 'eslint-plugin-vitest' plugin for ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,9 @@
 /**
  * @type {import('eslint').ESLint.ConfigData}
  * @see GitHub: {@link https://github.com/nuxt/eslint-config/ | nuxt/eslint-config}
+ * @see GitHub: {@link https://github.com/veritem/eslint-plugin-vitest/ | eslint-plugin-vitest}
+ * - Rule1: {@link https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-it.md | consistent-test-it}
+ * - Rule2: {@link https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md | require-top-level-describe}
  * @see ESLint Rules: {@link https://typescript-eslint.io/rules/explicit-function-return-type/ | explicit-function-return-type}
  * - NOTE: Return Typesの明示を必須にする
  * @see ESLint Rules: {@link https://typescript-eslint.io/rules/consistent-type-imports/ | consistent-type-imports}
@@ -14,13 +17,16 @@ module.exports = {
   env: {
     browser: true,
   },
-  extends: ["@nuxt/eslint-config", "prettier"],
+  plugins: ["vitest"],
+  extends: ["@nuxt/eslint-config", "plugin:vitest/recommended", "prettier"],
   rules: {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/consistent-type-imports": "off",
     "@typescript-eslint/no-import-side-effects": "off",
     "no-console": process.env.NODE_ENV === "production" ? "error" : "warn",
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "warn",
+    "vitest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
+    "vitest/require-top-level-describe": ["error"],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,15 +2,15 @@
 /**
  * @type {import('eslint').ESLint.ConfigData}
  * @see GitHub: {@link https://github.com/nuxt/eslint-config/ | nuxt/eslint-config}
+ *
  * @see GitHub: {@link https://github.com/veritem/eslint-plugin-vitest/ | eslint-plugin-vitest}
  * - Rule1: {@link https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/consistent-test-it.md | consistent-test-it}
  * - Rule2: {@link https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-top-level-describe.md | require-top-level-describe}
- * @see ESLint Rules: {@link https://typescript-eslint.io/rules/explicit-function-return-type/ | explicit-function-return-type}
- * - NOTE: Return Typesの明示を必須にする
- * @see ESLint Rules: {@link https://typescript-eslint.io/rules/consistent-type-imports/ | consistent-type-imports}
- * - NOTE: 型のimportを必須にする
- * @see ESLint Rules: {@link https://typescript-eslint.io/rules/no-import-type-side-effects/ | no-import-type-side-effects}
- * - NOTE: 型のimportで副作用を禁止する
+ *
+ * @see GitHub: {@link https://typescript-eslint.io/rules/ | @typescript-eslint/eslint-plugin}
+ * - Rule1: {@link https://typescript-eslint.io/rules/explicit-function-return-type/ | explicit-function-return-type} - Return Typesの明示を必須にする
+ * - Rule2: {@link https://typescript-eslint.io/rules/consistent-type-imports/ | consistent-type-imports} - 型のimportを必須にする
+ * - Rule3: {@link https://typescript-eslint.io/rules/no-import-type-side-effects/ | no-import-type-side-effects} - 型のimportで副作用を禁止する
  */
 module.exports = {
   root: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@
  * @see GitHub: {@link https://typescript-eslint.io/rules/ | @typescript-eslint/eslint-plugin}
  * - Rule1: {@link https://typescript-eslint.io/rules/explicit-function-return-type/ | explicit-function-return-type} - Return Typesの明示を必須にする
  * - Rule2: {@link https://typescript-eslint.io/rules/consistent-type-imports/ | consistent-type-imports} - 型のimportを必須にする
- * - Rule3: {@link https://typescript-eslint.io/rules/no-import-type-side-effects/ | no-import-type-side-effects} - 型のimportで副作用を禁止する
  */
 module.exports = {
   root: true,
@@ -22,7 +21,6 @@ module.exports = {
   rules: {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/consistent-type-imports": "off",
-    "@typescript-eslint/no-import-side-effects": "off",
     "no-console": process.env.NODE_ENV === "production" ? "error" : "warn",
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "warn",
     "vitest/consistent-test-it": ["error", { fn: "it", withinDescribe: "it" }],
@@ -36,10 +34,9 @@ module.exports = {
         "@typescript-eslint/consistent-type-imports": [
           "error",
           {
-            "disallowTypeAnnotations": false,
-          }
+            disallowTypeAnnotations: false,
+          },
         ],
-        "@typescript-eslint/no-import-side-effects": "error",
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@volar/vue-typescript": "^1.6.5",
         "eslint": "^8.46.0",
         "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-vitest": "^0.2.8",
         "histoire": "^0.16.5",
         "nuxt": "^3.6.5",
         "prettier": "^3.0.1",
@@ -7084,6 +7085,155 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-plugin-vitest": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vitest/-/eslint-plugin-vitest-0.2.8.tgz",
+      "integrity": "sha512-q8s4tStyKtn3gXf+8nf1ZYTHhoCXKdnozZzp6u8b4ni5v68Y4vxhNh4Z8njUfNjEY8HoPBB77MazHMR23IPb+g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^6.2.0"
+      },
+      "engines": {
+        "node": "14.x || >= 16"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
+      "integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/types": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
+      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/utils": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.4.1",
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/typescript-estree": "6.4.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
+      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint-plugin-vue": {
       "version": "9.16.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.16.1.tgz",
@@ -13896,6 +14046,18 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@volar/vue-typescript": "^1.6.5",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-vitest": "^0.2.8",
     "histoire": "^0.16.5",
     "nuxt": "^3.6.5",
     "prettier": "^3.0.1",


### PR DESCRIPTION
## Issue

closed #25 .

## 内容

- [x] Vitest用ESLintプラグイン **[eslint-plugin-vitest](https://github.com/veritem/eslint-plugin-vitest)** 
を追加しました
- [x] #24 で追加した'@typescript-eslint/no-import-side-effects'を削除しました
  - [no-import-type-side-effects](https://typescript-eslint.io/rules/no-import-type-side-effects/)のドキュメントを再度確認し、以下の記述を確認したため。

  > If you're not using TypeScript 5.0's verbatimModuleSyntax option, then you don't need this rule.

- [x] `.eslintrc.js`内のJSDoc記述を一部修正しました

### 関連
- https://www.npmjs.com/package/eslint-plugin-vitest
- [Zenn#TypeScript 5.0 で追加された 
verbatimModuleSyntax とは何か？](https://zenn.dev/teppeis/articles/2023-04-typescript-5_0-verbatim-module-syntax)
