### PR TITLE
#20: add 'vue-i18n' in Vite AutoImport setting.

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -11,7 +11,7 @@ export default defineConfig({
   plugins: [
     Vue(),
     AutoImport({
-      imports: ["vue", "vue-router", "pinia"],
+      imports: ["vue", "vue-router", "pinia", "vue-i18n"],
       dts: "src/.nuxt/auto-imports.d.ts",
     }),
   ],


### PR DESCRIPTION
## Issue

closed #20 .

## 内容

- [x] `vite.config.ts`のAutoImports設定に **vue-i18n** を追加しました。
  - #28 で`useI18n`などが自動生成されているのを確認した。`.nuxt/imports.d.ts`内にexportされていた。

## 備考
`useI18n`と合わせて以下の生成も確認済み(`vue-i18n`、`@nuxtjs/i18n`関連のみ抽出)

```ts
// .nuxt/imports.d.ts

export {
  defineI18nConfig,
  defineI18nLocale,
  defineI18nRoute,
  useBrowserLocale,
  useCookieLocale,
  useLocaleHead,
  useLocalePath,
  useLocaleRoute,
  useRouteBaseName,
  useSwitchLocalePath,
} from "../../node_modules/@nuxtjs/i18n/dist/runtime/composables";
export { useI18n } from "../../node_modules/vue-i18n/dist/vue-i18n";
```


### 関連
- #20
- #28
