### PR TITLE
#32: add 'vueuse' in Spelling Checker for VS Code.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "composables",
     "histoire",
     "pinia",
-    "persistedstate"
+    "persistedstate",
+    "vueuse"
   ]
 }


### PR DESCRIPTION
## Issue

closed #32 .

## 内容

- [x] Code Spell Checker (for VS Code)の設定に **vueuse**を追加しました
  - #33 でcommit対応が漏れていた内容

### 関連

- #33
